### PR TITLE
Fix docker compose for M1 (Apple Silicon) hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.9'
 
 services:
   mysql:
+    platform: linux/x86_64
     image: mysql:5.7
     ports:
       - '3306:3306'


### PR DESCRIPTION
It fixes the error: 'no matching manifest for linux/arm64/v8 in the manifest list entries' when running yarn start.