### PR TITLE
Update documentation related to running contract tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ You can also provide the path to a local pact file in case you want to test new 
 PACT_FILE=../api.serlo.org/pacts/api.serlo.org-serlo.org-database-layer.json ./scripts/pacts.sh
 ```
 
+You can generate the pacts .json file (`api.serlo.org-serlo.org-database-layer.json`) locally by checking out the [api.serlo.org/](https://github.com/serlo/api.serlo.org/)
+repository and running `yarn pacts` at the root of the cloned repository. The generated .json file will be in `path_to_api.serlo.org_repository/pacts`.
+
 ### Other helpful commands
 
 - `cargo test` – Run all tests (see https://doc.rust-lang.org/book/ch11-01-writing-tests.html )


### PR DESCRIPTION
Added a paragraph to share how to generate the pacts .json file locally.

Related to https://github.com/serlo/database-layer/issues/458.

ℹ️ This is a draft PR because the [Pacts](https://github.com/serlo/database-layer/actions/workflows/pacts.yml) workflow is broken, and hence the `Pacts / pacts_test (pull_request)` check is not passing, yet.