### PR TITLE
chore(dependabot): Add `@` to `types/node`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       interval: 'weekly'
     ignore:
       # we want LTS version of node and not suggested current version
-      - dependency-name: 'types/node'
+      - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
 
 


### PR DESCRIPTION
In order to ignore major versions of `@types/node`.

Follow up of https://github.com/serlo/database-layer/pull/474.