### PR TITLE
chore(docker): switch from debian slim base image to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM rust:1.70 as build
+FROM rust:1.70-alpine3.18 as build
 WORKDIR /usr/src/app
+RUN apk update && apk add --no-cache musl-dev pkgconfig openssl-dev
 COPY server server
 COPY test-utils test-utils
 COPY Cargo.lock .
 COPY Cargo.toml .
 COPY sqlx-data.json .
-RUN cargo build --release
+RUN RUSTFLAGS='-C target-feature=-crt-static' cargo build --release
 
-FROM debian:buster-slim
+FROM alpine:3.18
 WORKDIR /usr/src/app
-RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk add --no-cache openssl openssl-dev libgcc
 COPY --from=build /usr/src/app/target/release/server .
 CMD ["./server"]
 EXPOSE 8080


### PR DESCRIPTION
reducing the image size from 102 MB to 38 MB

@eliflores and I built the image 
`docker build -t database-layer:alpine .`
and ran a container from this image with
`docker run --env-file .env --network database-layer_default --rm -p 8080:8080 database-layer:alpine` with `localhost` in .env replaced by `mysql`.
A 
`yarn fetch UuidQuery '{"id": 1}'`
was then successful. 