### PR TITLE
Update local MySQL DB configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,6 @@ services:
   mysql:
     image: eu.gcr.io/serlo-shared/serlo-mysql-database:latest
     platform: linux/x86_64
+    pull_policy: always
     ports:
       - '3306:3306'


### PR DESCRIPTION
So that the latest image of serlo-mysql-database is always pulled, and the latest version of the image is always used.

ℹ️ Similar to: https://github.com/serlo/db-migrations/pull/124